### PR TITLE
Add CLOUD_IMAGE_CACHE env var to control existing image handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Configuration file can be managed manually or through the web UI (Cluster Manage
 |----------|-------------|---------|
 | `CONFIG_FILE_PATH` | Path to the main configuration file | `./data/config.toml` |
 | `CLOUD_IMAGES_PATH` | Path to custom cloud images JSON file | `./cloud_images.json` |
+| `CLOUD_IMAGE_CACHE` | How to handle existing cloud images: `REUSE` (skip download if exists) or `OVERWRITE` (delete and re-download) | `REUSE` |
 
 ### Custom Cloud Images
 


### PR DESCRIPTION
- CLOUD_IMAGE_CACHE=REUSE (default): Reuse existing cached images, skip download if image already exists on storage
- CLOUD_IMAGE_CACHE=OVERWRITE: Delete existing image and download fresh

Behavior:
- Checks if image exists before downloading
- REUSE mode: skips download, keeps image after template creation
- OVERWRITE mode: deletes existing, downloads fresh, cleans up after

Fixes "refusing to override existing file" error when image already exists on storage.