### PR TITLE
Add demo deployment to release workflow

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -259,7 +259,7 @@ jobs:
           type=raw,value=latest
         flavor: |
           latest=false
-    
+
     - name: Build and push
       id: build
       uses: docker/build-push-action@v5
@@ -271,10 +271,54 @@ jobs:
         labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
-        
+
     - name: Generate artifact attestation
       uses: actions/attest-build-provenance@v1
       with:
         subject-name: ghcr.io/${{ github.repository }}
         subject-digest: ${{ steps.build.outputs.digest }}
         push-to-registry: true
+
+  # Deploy to demo server after release build
+  deploy-demo:
+    runs-on: ubuntu-latest
+    needs: [build-release]
+    if: github.event_name == 'release'
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Tailscale
+      uses: tailscale/github-action@v2
+      with:
+        oauth-client-id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
+        oauth-secret: ${{ secrets.TAILSCALE_OAUTH_SECRET }}
+        tags: tag:ci
+
+    - name: Deploy to demo server
+      env:
+        DEMO_SSH_HOST: ${{ secrets.DEMO_SSH_HOST }}
+        DEMO_SSH_USER: ${{ secrets.DEMO_SSH_USER }}
+        SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+      run: |
+        # Setup SSH key
+        mkdir -p ~/.ssh
+        echo "$SSH_PRIVATE_KEY" > ~/.ssh/id_rsa
+        chmod 600 ~/.ssh/id_rsa
+
+        # Add host to known_hosts (skip host key verification for Tailscale IPs)
+        ssh-keyscan -H "$DEMO_SSH_HOST" >> ~/.ssh/known_hosts 2>/dev/null || true
+
+        # Copy docker-compose.yml to demo server
+        scp -o StrictHostKeyChecking=no demo/docker-compose.yml "${DEMO_SSH_USER}@${DEMO_SSH_HOST}:/data/proxui-demo/docker-compose.yml"
+
+        # Restart demo instance
+        ssh -o StrictHostKeyChecking=no "${DEMO_SSH_USER}@${DEMO_SSH_HOST}" << 'EOF'
+          cd /data/proxui-demo
+          docker compose pull
+          docker compose up -d --force-recreate
+          docker image prune -f
+        EOF
+
+        echo "Demo deployed successfully!"

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  proxui:
+    image: ghcr.io/greenlogles/proxui:latest
+    container_name: proxui
+    privileged: true
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./proxui-data:/app/data
+    environment:
+      - FLASK_ENV=production
+      - PROXUI_DEMO_MODE=true
+      - PROXUI_DEMO_MESSAGE=This is a public demo with read-only access. Feel free to explore all features!
+    restart: unless-stopped


### PR DESCRIPTION
- Add demo/docker-compose.yml for demo server deployment
- Enable demo mode with PROXUI_DEMO_MODE environment variable
- Add deploy-demo job to CI/CD workflow
- Auto-deploy to demo server after release via Tailscale SSH
- Pulls latest image and restarts container on release