### PR TITLE
Milestone/lxc cloudinit alpine

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -195,12 +195,20 @@ jobs:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-    
+
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
     - name: Extract metadata
       id: meta
       uses: docker/metadata-action@v5
       with:
-        images: ghcr.io/${{ github.repository }}
+        images: |
+          ghcr.io/${{ github.repository }}
+          docker.io/greenlogles/proxui
         tags: |
           type=raw,value=testing
           type=sha,prefix={{branch}}-
@@ -249,12 +257,20 @@ jobs:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-    
+
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
     - name: Extract metadata
       id: meta
       uses: docker/metadata-action@v5
       with:
-        images: ghcr.io/${{ github.repository }}
+        images: |
+          ghcr.io/${{ github.repository }}
+          docker.io/greenlogles/proxui
         tags: |
           type=ref,event=tag
           type=raw,value=latest

--- a/app.py
+++ b/app.py
@@ -1110,6 +1110,38 @@ def get_qemu_guest_disk_info(proxmox, node, vmid):
         return None
 
 
+def get_lxc_disk_info(status):
+    """Build rootfs disk-usage info for an LXC container from status/current.
+
+    Containers have no guest agent, but the host reports the container's rootfs
+    usage directly — the same value 'pct df' shows for the rootfs mountpoint.
+    Only the rootfs is exposed via the API; per-mountpoint usage (mp0, mp1, …)
+    that 'pct df' also prints has no REST equivalent.
+
+    Returns a one-element list shaped like get_qemu_guest_disk_info so the same
+    template UI can render it, or None when usage is unavailable.
+    """
+    total_bytes = status.get("maxdisk") or 0
+    used_bytes = status.get("disk") or 0
+    if total_bytes <= 0:
+        return None
+
+    return [
+        {
+            "name": "rootfs",
+            "mountpoint": "/",
+            "type": "rootfs",
+            "used_bytes": used_bytes,
+            "total_bytes": total_bytes,
+            "disk_name": "rootfs",
+            "used_percent": (used_bytes / total_bytes) * 100,
+            "used_gb": used_bytes / (1024**3),
+            "total_gb": total_bytes / (1024**3),
+            "free_gb": (total_bytes - used_bytes) / (1024**3),
+        }
+    ]
+
+
 def is_agent_enabled(config):
     """True if a VM config's 'agent' value has the guest agent enabled.
 
@@ -2359,6 +2391,10 @@ def vm_detail(node, vmid):
             and is_agent_enabled(config)
         ):
             guest_disk_info = get_qemu_guest_disk_info(proxmox, node, vmid)
+        elif vm_type == "lxc" and status.get("status") == "running":
+            # Containers have no guest agent; the host reports rootfs usage
+            # directly via status/current (same as 'pct df' rootfs row).
+            guest_disk_info = get_lxc_disk_info(status)
 
         # Check for active migration tasks
         migration_info = None

--- a/templates/vm_detail.html
+++ b/templates/vm_detail.html
@@ -215,11 +215,11 @@
 <div class="row">
     
     <div class="col-md-6 mb-3">
-        {% if guest_disk_info and vm_type == 'qemu' %}
+        {% if guest_disk_info %}
         <!-- Guest Disk Usage Card -->
         <div class="card">
             <div class="card-header">
-                <h5 class="mb-0"><i class="bi bi-hdd"></i> Guest Disk Usage</h5>
+                <h5 class="mb-0"><i class="bi bi-hdd"></i> {{ 'Disk Usage' if vm_type == 'lxc' else 'Guest Disk Usage' }}</h5>
             </div>
             <div class="card-body">
                 <div style="max-height: 300px; overflow-y: auto;">

--- a/templates/vm_edit.html
+++ b/templates/vm_edit.html
@@ -2971,7 +2971,7 @@ function cloudInit(node, vmid) {
     nativeBusy: false, nativeError: '', nativeSuccess: '',
     // Snippet fields
     cicustom: {{ config.get('cicustom', '') | tojson }},
-    snippetStorages: [], snippetStorage: '', snippetStoragesLoaded: false,
+    snippetStorages: [], snippetStorage: '', sshStatusLoaded: false,
     snippetFilename: `${vmid}-user-data.yaml`,
     snippetContent: '',
     template: '',
@@ -3076,10 +3076,13 @@ function cloudInit(node, vmid) {
     },
 
     async initSnippetTab() {
-      if (!this.snippetStoragesLoaded) {
-        await this.loadStorages();
+      // Always refresh the storage list on tab open so a storage that was
+      // created or had snippets enabled after the page loaded (here or in the
+      // Proxmox UI) is reflected without a full page reload.
+      await this.loadStorages(this.snippetStorage);
+      if (!this.sshStatusLoaded) {
         await this.loadSshStatus();
-        this.snippetStoragesLoaded = true;
+        this.sshStatusLoaded = true;
       }
       // Load existing snippet content if attached and not yet loaded
       if (this.cicustom && !this.snippetContent) {

--- a/tests/test_vm_management.py
+++ b/tests/test_vm_management.py
@@ -15,6 +15,7 @@ from app import (
     cluster_nodes,
     get_all_vms_and_containers,
     get_all_vms_and_containers_fallback,
+    get_lxc_disk_info,
     get_qemu_guest_disk_info,
     parse_ssh_keys,
     parse_vm_configuration,
@@ -227,6 +228,30 @@ class TestVMManagement(unittest.TestCase):
         result = get_qemu_guest_disk_info(mock_proxmox, "test-node", "100")
 
         self.assertIsNone(result)
+
+    def test_get_lxc_disk_info_success(self):
+        """Test LXC rootfs disk info derived from status/current"""
+        status = {
+            "status": "running",
+            "disk": 1181116006,  # ~1.1GB used
+            "maxdisk": 20937965568,  # ~19.5GB total
+        }
+
+        result = get_lxc_disk_info(status)
+
+        self.assertEqual(len(result), 1)
+        disk = result[0]
+        self.assertEqual(disk["mountpoint"], "/")
+        self.assertEqual(disk["type"], "rootfs")
+        self.assertEqual(disk["used_bytes"], 1181116006)
+        self.assertEqual(disk["total_bytes"], 20937965568)
+        self.assertAlmostEqual(disk["used_percent"], 5.64, places=1)
+        self.assertAlmostEqual(disk["total_gb"], 19.5, places=1)
+
+    def test_get_lxc_disk_info_no_maxdisk(self):
+        """Test LXC disk info returns None when total size is unknown"""
+        self.assertIsNone(get_lxc_disk_info({"status": "running", "disk": 0}))
+        self.assertIsNone(get_lxc_disk_info({"status": "running", "maxdisk": 0}))
 
     def test_parse_vm_configuration(self):
         """Test VM configuration parsing"""


### PR DESCRIPTION
  - LXC rootfs disk usage on the detail page — containers have no guest agent, so we read the host-reported rootfs usage from status/current (the same value pct df shows) and render it through the existing disk-usage UI. Per-mountpoint usage (mp0, etc.) has no REST equivalent, so only rootfs is shown.
  - Push Docker images to Docker Hub — the build-testing and build-release workflow jobs now push the multi-arch image to docker.io/greenlogles/proxui alongside ghcr.io. 
  - Fix stale "Enable snippets" prompt — the cloud-init snippet tab loaded the storage list only once, so a storage enabled after page load kept showing the prompt. It now re-fetches on   tab open (preserving the current selection).

