### PR TITLE
LXC disk usage, Docker Hub image, cloud-init snippet fixes

### DIFF
--- a/templates/vm_edit.html
+++ b/templates/vm_edit.html
@@ -3069,6 +3069,10 @@ function cloudInit(node, vmid) {
           body: JSON.stringify({ node, storage: this.selectedStorage.storage }),
         });
         this.setupOk = true; this.setupMsg = r.message || 'Snippets enabled.';
+        // Optimistically flip the flag so the alert clears immediately even if
+        // the user stays on the tab, then reconcile with the server.
+        const s = this.snippetStorages.find(x => x.storage === this.snippetStorage);
+        if (s) s.snippets_enabled = true;
         await this.loadStorages(this.snippetStorage);
       } catch(e) {
         this.setupOk = false; this.setupMsg = e.message || 'Could not enable snippets';

--- a/templates/vm_edit.html
+++ b/templates/vm_edit.html
@@ -618,7 +618,8 @@
                         </div>
                         <div class="col-sm-4">
                             <label class="form-label small fw-semibold">Storage</label>
-                            <select class="form-select form-select-sm" x-model="snippetStorage">
+                            <select class="form-select form-select-sm" x-model="snippetStorage"
+                                    @change="recomputeSelectedStorage()">
                                 <option value="">— select storage —</option>
                                 <template x-for="s in snippetStorages" :key="s.storage">
                                     <option :value="s.storage" x-text="storageLabel(s)"></option>
@@ -2971,7 +2972,7 @@ function cloudInit(node, vmid) {
     nativeBusy: false, nativeError: '', nativeSuccess: '',
     // Snippet fields
     cicustom: {{ config.get('cicustom', '') | tojson }},
-    snippetStorages: [], snippetStorage: '', sshStatusLoaded: false,
+    snippetStorages: [], snippetStorage: '', selectedStorage: null, sshStatusLoaded: false,
     snippetFilename: `${vmid}-user-data.yaml`,
     snippetContent: '',
     template: '',
@@ -2990,8 +2991,13 @@ function cloudInit(node, vmid) {
       return /(^|,)\s*user=/.test(this.cicustom || '');
     },
 
-    get selectedStorage() {
-      return this.snippetStorages.find(s => s.storage === this.snippetStorage) || null;
+    // Plain reactive property, recomputed explicitly via recomputeSelectedStorage().
+    // Not a getter: a getter that conditionally reads its deps (find() skips the
+    // callback on an empty array, so snippetStorage goes untracked on first run)
+    // could leave x-show bindings stale after the storage list loads.
+    recomputeSelectedStorage() {
+      this.selectedStorage =
+        this.snippetStorages.find(s => s.storage === this.snippetStorage) || null;
     },
 
     storageLabel(s) {
@@ -3018,6 +3024,7 @@ function cloudInit(node, vmid) {
             || this.snippetStorages.find(s => s.snippets_enabled);
           if (best) this.snippetStorage = best.storage;
         }
+        this.recomputeSelectedStorage();
       } catch(e) { this.snippetError = e.message; }
     },
 
@@ -3073,6 +3080,7 @@ function cloudInit(node, vmid) {
         // the user stays on the tab, then reconcile with the server.
         const s = this.snippetStorages.find(x => x.storage === this.snippetStorage);
         if (s) s.snippets_enabled = true;
+        this.recomputeSelectedStorage();
         await this.loadStorages(this.snippetStorage);
       } catch(e) {
         this.setupOk = false; this.setupMsg = e.message || 'Could not enable snippets';

--- a/templates/vm_edit.html
+++ b/templates/vm_edit.html
@@ -644,13 +644,17 @@
                             (cloud-init would lose it). Prefer a shared storage, or
                             <a href="#" @click.prevent="createSharedStorage()">create a shared /etc/pve snippet storage</a>.
                         </div>
-                        <!-- Chosen storage lacks the snippets content type -->
-                        <div x-show="selectedStorage && !selectedStorage.snippets_enabled"
-                             class="alert alert-info py-2 small mb-2 d-flex align-items-center gap-2">
-                            <span>Storage <code x-text="selectedStorage && selectedStorage.storage"></code>
-                                doesn't allow snippets yet.</span>
-                            <button class="btn btn-sm btn-outline-primary py-0 ms-auto"
-                                    @click="enableSnippets()" :disabled="setupBusy">Enable snippets</button>
+                        <!-- Chosen storage lacks the snippets content type.
+                             x-show lives on a wrapper without .d-flex: Bootstrap's
+                             `.d-flex { display: flex !important }` would otherwise
+                             override the inline `display:none` x-show sets. -->
+                        <div x-show="selectedStorage && !selectedStorage.snippets_enabled">
+                            <div class="alert alert-info py-2 small mb-2 d-flex align-items-center gap-2">
+                                <span>Storage <code x-text="selectedStorage && selectedStorage.storage"></code>
+                                    doesn't allow snippets yet.</span>
+                                <button class="btn btn-sm btn-outline-primary py-0 ms-auto"
+                                        @click="enableSnippets()" :disabled="setupBusy">Enable snippets</button>
+                            </div>
                         </div>
                         <!-- Access status + actions -->
                         <div class="d-flex align-items-center gap-2 flex-wrap small">

--- a/templates/vm_edit.html
+++ b/templates/vm_edit.html
@@ -666,7 +666,8 @@
                             </span>
                             <button x-show="ssh.checked && !ssh.sftp_ok" class="btn btn-sm btn-outline-secondary py-0"
                                     @click="showSetup = !showSetup">Set up access</button>
-                            <button class="btn btn-sm btn-outline-secondary py-0"
+                            <button x-show="!snippetStorages.some(s => s.shared && s.snippets_enabled)"
+                                    class="btn btn-sm btn-outline-secondary py-0"
                                     @click="createSharedStorage()" :disabled="setupBusy"
                                     title="Create a cluster-shared snippet storage on /etc/pve (migration-safe)">
                                 <i class="bi bi-hdd-network"></i> Create shared /etc/pve storage


### PR DESCRIPTION
## Summary

- **LXC rootfs disk usage on the VM detail page.** Containers have no guest agent, so usage is read from the host-reported `status/current` (`disk`/`maxdisk`) — the same value `pct df` shows for the rootfs row — and rendered through the existing disk-usage UI. Per-mountpoint usage (mp0, …) has no REST equivalent, so only rootfs is shown.
- **Publish the Docker image to Docker Hub.** The `build-testing` and `build-release` workflow jobs now push the multi-arch image to `docker.io/greenlogles/proxui` alongside `ghcr.io`, with a Docker Hub login step. **Requires `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` repo secrets.**
- **Cloud-init snippet tab fixes:**
  - Fix the persistent **"Enable snippets" alert** that stayed visible for storages where snippets were already enabled. Root cause: the alert element carried Bootstrap's `.d-flex` (`display: flex !important`), which overrode the inline `display: none` that Alpine's `x-show` sets — so it could never be hidden regardless of state. Moved `x-show` to a plain wrapper with `.d-flex` on an inner div.
  - Refresh the storage list on tab open, so storages created or snippet-enabled after the page loaded are reflected without a full reload.
  - Make `selectedStorage` a plain reactive property instead of a getter (more predictable reactivity).
  - Hide the **"Create shared /etc/pve storage"** button when a suitable shared, snippets-enabled storage already exists.

