### PR TITLE
Clear Docker image CVEs: drop gosu and setuptools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,12 @@ WORKDIR /app
 COPY requirements.txt .
 
 RUN pip install --no-cache-dir -r requirements.txt && \
-    apt-get update && apt-get install -y --no-install-recommends curl gosu && \
+    # Drop pip/setuptools from the runtime image: not needed to run the app, and
+    # setuptools vendors jaraco.context which trips vulnerability scanners.
+    pip uninstall -y pip setuptools && \
+    # curl is for the HEALTHCHECK. gosu is intentionally omitted — entrypoint.sh
+    # uses setpriv (util-linux) to avoid pulling in a Go binary.
+    apt-get update && apt-get install -y --no-install-recommends curl && \
     rm -rf /var/lib/apt/lists/*
 
 # Labels

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,4 +6,7 @@ set -e
 mkdir -p /app/data
 chown -R proxui:proxui /app/data
 
-exec gosu proxui "$@"
+# Drop from root to the proxui user with setpriv (util-linux, already in the
+# base image) instead of gosu, which is a static Go binary that drags Go stdlib
+# CVEs into vulnerability scans despite not using those code paths.
+exec setpriv --reuid proxui --regid proxui --init-groups "$@"


### PR DESCRIPTION
## Summary

Clears the vulnerability-scanner findings on the published Docker image. Neither source is used by ProxUI at runtime:

- **Go stdlib CVEs** (e.g. CVE-2025-68121 and the `golang/stdlib` set) came from **`gosu`**, a static Go binary the Dockerfile installed to drop root→`proxui` in the entrypoint. Scanners read the Go stdlib version compiled into it and flag every Go CVE, even though gosu (a setuid+exec helper) never runs the vulnerable code paths.
- **`jaraco.context` (CVE-2026-23949)** is vendored inside **`setuptools`**, which ships in the `python:3.11-slim` base — not a runtime dependency.

## Changes

- **`entrypoint.sh`**: `gosu proxui` → `setpriv --reuid proxui --regid proxui --init-groups` (util-linux, already in the base image). No Go binary.
- **`Dockerfile`**: drop `gosu` from the apt install (keep `curl` for the healthcheck); `pip uninstall -y pip setuptools` after installing requirements (removes vendored jaraco.context, shrinks attack surface).

## Verification (fresh local build)

- `gosu` gone, `setpriv` present, `setuptools` gone, `jaraco` gone, **no Go binaries** remain.
- Container builds, serves `HTTP 200`, `/app/data` owned by `proxui`, and PID 1 (the app) runs as **uid 1000 (proxui)** — privilege drop verified.

## Note

The CVEs live in the already-published `v0.8.0` / `latest` / `testing` images; they clear only once the image is rebuilt and republished from this change.
