### PR TITLE
fix: parse storage ID from volid when deleting ISO/template

### DIFF
--- a/app.py
+++ b/app.py
@@ -3344,12 +3344,11 @@ def api_delete_iso(node, volid):
         return jsonify({"error": "Node not found"}), 404
 
     try:
-        # volid format: storage/filename.iso
-        parts = volid.split("/")
-        if len(parts) != 2:
+        # volid format: storage:content-type/filename.iso (e.g. local:iso/foo.iso)
+        if ":" not in volid or "/" not in volid:
             return jsonify({"error": "Invalid volume ID format"}), 400
 
-        storage = parts[0]
+        storage = volid.split(":")[0]
         proxmox.nodes(node).storage(storage).content(volid).delete()
 
         return jsonify(
@@ -3395,12 +3394,12 @@ def api_delete_lxc_template(node, volid):
         return jsonify({"error": "Node not found"}), 404
 
     try:
-        # volid format: storage/template-name.tar.xz
-        parts = volid.split("/")
-        if len(parts) != 2:
+        # volid format: storage:content-type/template-name.tar.xz
+        # (e.g. local:vztmpl/debian-12.tar.zst)
+        if ":" not in volid or "/" not in volid:
             return jsonify({"error": "Invalid volume ID format"}), 400
 
-        storage = parts[0]
+        storage = volid.split(":")[0]
         proxmox.nodes(node).storage(storage).content(volid).delete()
 
         return jsonify(

--- a/static/js/isos.js
+++ b/static/js/isos.js
@@ -157,7 +157,7 @@ export function isosManager() {
     // ── Display helpers ───────────────────────────────────────────────────────
 
     isoFilename(volid) { return (volid || '').split('/').pop(); },
-    isoStorage(volid) { return (volid || '').split('/')[0] || ''; },
+    isoStorage(volid) { return (volid || '').split(':')[0] || ''; },
     isoSizeGB(iso) { return iso.size ? (iso.size / 1073741824).toFixed(2) : 'Unknown'; },
     vmMemGB(vm) { return vm.maxmem ? (vm.maxmem / 1073741824).toFixed(1) : 'Unknown'; },
     vmCpuInfo(vm) { return vm.cpus ? `${vm.cpus} cores` : 'Unknown'; },


### PR DESCRIPTION
Proxmox volids have the format storage:content-type/filename (e.g. local-ssd:vztmpl/debian-12.tar.zst). The delete endpoints split the volid on '/', so parts[0] became 'local-ssd:vztmpl' and was passed as the storage ID, which Proxmox rejects with 'contains illegal characters'. Derive the storage ID from the part before the colon instead, and fix the same bug in the isoStorage display helper.